### PR TITLE
Pressing mentor link now opens a new tab

### DIFF
--- a/2021/sections/volunteers.html
+++ b/2021/sections/volunteers.html
@@ -3,7 +3,7 @@
 
 <h2>Interested in helping?</h2>
 <p>Our alumni and industry connections are the secret sauce. Please consider volunteering as a mentor or as a judge at this year's HackOHI/O, or contact us to lead a workshop on campus or online. Please sign up below!</p>
-<div class="reg-button" style="padding: 5%;"><a id="apply" href="https://docs.google.com/forms/d/e/1FAIpQLSfy3WKKQq6iqFimAjtlkVsvP3XnJzvyYAf4cWpHOQ6QNIVdaA/viewform">Mentor/Judge at HackOHIO!</a></div>
+<div class="reg-button" style="padding: 5%;"><a id="apply" href="https://docs.google.com/forms/d/e/1FAIpQLSfy3WKKQq6iqFimAjtlkVsvP3XnJzvyYAf4cWpHOQ6QNIVdaA/viewform" target="_blank" rel="noopener nonreferrer">Mentor/Judge at HackOHIO!</a></div>
 <br/>
 
 <h2>Already signed up to Judge/Mentor?</h2>
@@ -12,3 +12,5 @@
 <br/>
 
 <h4>For any questions/concerns please contact us via <a href="mailto:hackathon@osu.edu">hackathon@osu.edu</a></h4>
+
+


### PR DESCRIPTION
When you press the mentor link button in the volunteer section it now opens the google doc in a new page.